### PR TITLE
Basic manual context trimming to avoid token limit

### DIFF
--- a/simple-chat.py
+++ b/simple-chat.py
@@ -230,7 +230,7 @@ with gr.Blocks(css=css, title="Simple Chat") as demo:
             with gr.Column():
                 with gr.Row():
                     prevGenLen = gr.Number(label='Previous Gen History Limit')
-                    prevTokenTotal = gr.Number(label='Previous Gen Token Total')
+                    prevTokenTotal = gr.Number(label='Previous Gen Token Total (Max: 4096)')
 
         
     #Bindings


### PR DESCRIPTION
If interested, this is a simple update to provide the user an easy way to avoid the token limit by specifying how many past messages to send to the API. The message count does not factor in the assistant 'system' message or the user's new message. Those are added after the trim occurs.

This allows the user to be able to continue their conversation well after the max length has been exceeded without needing to modify the content of their conversation.

The history length is controlled by a slider in the advanced settings. To help the user determine the right number of messages to include, two number fields are also added that show the user the number of messages sent in the last request and how many tokens were used.  If you just want the slider, all changes are present in the first commit.

This is a stopgap measure while a better solution is worked on. I'm looking into providing token estimates prior to sending the chat, and of course, automatic trimming of content.  In the meantime this provides a workaround.

Feel free to reject or modify if this does  not conform with your vision of the app.